### PR TITLE
Made all paths relative

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "AXI4"]
 	path = AXI4
-	url = https://github.com/OSVVM/AXI4.git
+	url = ../OSVVM/AXI4.git
 [submodule "Scripts"]
 	path = Scripts
 	url = ../OSVVM-Scripts.git


### PR DESCRIPTION
`.gitmodules` contained a non-relative path to the AXI4 repository.

Non-relative relative paths create problems in forked environments and on CI servers.